### PR TITLE
Container rework

### DIFF
--- a/config/configCephasonics3D.xml
+++ b/config/configCephasonics3D.xml
@@ -27,11 +27,11 @@
 				<param name="numScanlinesY" type="uint32_t">
 					16
 				</param>
-				<param name="rxNumScanlinesX" type="uint32_t">
-					32
+				<param name="rxScanlineSubdivisionX" type="uint32_t">
+					1
 				</param>
-				<param name="rxNumScanlinesY" type="uint32_t">
-					16
+				<param name="rxScanlineSubdivisionY" type="uint32_t">
+					1
 				</param>
 				<param name="numSamplesRecon" type="uint32_t">
 					2000
@@ -173,6 +173,12 @@
 			<node type="LogCompressorNode" id="LOGC">
 			</node>
 			<node type="ScanConverterNode" id="SCAN">
+				<param name="imageResolutionForced" type="bool">
+					1
+				</param>
+				<param name="imageResolution" type="double">
+					0.15
+				</param>
 			</node>
 		</nodes>
 	</devices>

--- a/src/GraphicInterface/previewBuilderQt.cpp
+++ b/src/GraphicInterface/previewBuilderQt.cpp
@@ -120,7 +120,7 @@ namespace supra
 							auto inImageData = inImage8Bit->getData();
 							if (!inImageData->isHost())
 							{
-								inImageData = inImageData->getCopy(ContainerLocation::LocationHost);
+								inImageData = make_shared<Container<uint8_t> >(LocationHost, *inImageData);
 							}
 							qtimage = std::make_shared<QImage>(
 								static_cast<int>(inImage8Bit->getSize().x),
@@ -141,7 +141,7 @@ namespace supra
 							auto inImageData = inImage16Bit->getData();
 							if (!inImageData->isHost())
 							{
-								inImageData = inImageData->getCopy(ContainerLocation::LocationHost);
+								inImageData = make_shared<Container<int16_t> >(LocationHost, *inImageData);
 							}
 							qtimage = std::make_shared<QImage>(
 								static_cast<int>(inImage16Bit->getSize().x),

--- a/src/SupraLib/Beamformer/LogCompressor.cu
+++ b/src/SupraLib/Beamformer/LogCompressor.cu
@@ -48,13 +48,12 @@ namespace supra
 		size_t height = size.y;
 		size_t depth = size.z;
 
-		auto pComprGpu = make_shared<Container<uint8_t> >(LocationGpu, width*height*depth);
+		auto pComprGpu = make_shared<Container<uint8_t> >(LocationGpu, inImageData->getStream(), width*height*depth);
 
 		thrustLogcompress<int16_t, uint8_t, WorkType> c(pow(10, (dynamicRange / 20)), static_cast<int16_t>(inMax), std::numeric_limits<uint8_t>::max(), scale);
-		thrust::transform(thrust::device, inImageData->get(), inImageData->get() + (width*height*depth),
+		thrust::transform(thrust::cuda::par.on(inImageData->getStream()), inImageData->get(), inImageData->get() + (width*height*depth),
 			pComprGpu->get(), c);
 		cudaSafeCall(cudaPeekAtLastError());
-		cudaSafeCall(cudaStreamSynchronize(cudaStreamPerThread));
 
 		return pComprGpu;
 	}

--- a/src/SupraLib/Beamformer/TemporalFilter.cu
+++ b/src/SupraLib/Beamformer/TemporalFilter.cu
@@ -79,7 +79,7 @@ namespace supra
 			}
 			else
 			{
-				auto copy = make_shared<Container<int16_t> >(LocationHost, *thisImageData);
+				auto copy = make_shared<Container<int16_t> >(LocationGpu, *thisImageData);
 				copiedImages.push_back(copy);
 				imagePointersContainer.get()[imageIndex] = copy->get();
 			}

--- a/src/SupraLib/Beamformer/WindowFunction.cpp
+++ b/src/SupraLib/Beamformer/WindowFunction.cpp
@@ -43,7 +43,7 @@ namespace supra
 
 		//Create the storage for the window functions
 		m_dataGpu = unique_ptr<Container<ElementType> >(
-			new Container<ElementType>(LocationGpu, m_data));
+			new Container<ElementType>(LocationGpu, cudaStreamPerThread, m_data));
 
 		m_gpuFunction = WindowFunctionGpu(m_numEntriesPerFunction, m_dataGpu->get());
 	}

--- a/src/SupraLib/CMakeLists.txt
+++ b/src/SupraLib/CMakeLists.txt
@@ -100,7 +100,8 @@ ENDIF(SUPRA_PROFILING)
 
 ############################################
 #lib base source files
-SET(SUPRA_Lib_SOURCE 
+SET(SUPRA_Lib_SOURCE
+	ContainerFactory.cpp
 	SupraManager.cpp
 	RecordObject.cpp
 	SyncRecordObject.cpp
@@ -122,6 +123,7 @@ SET(SUPRA_Lib_SOURCE
 SET(SUPRA_Lib_HEADERS
 	vec.h
 	Container.h
+	ContainerFactory.h
 	SupraManager.h
 	RecordObject.h
 	SyncRecordObject.h

--- a/src/SupraLib/CMakeLists.txt
+++ b/src/SupraLib/CMakeLists.txt
@@ -119,6 +119,7 @@ SET(SUPRA_Lib_SOURCE
 	utilities/SingleThreadTimer.cpp
 	utilities/tinyxml2/tinyxml2.cpp
 	FrequencyLimiterNode.cpp
+	StreamSyncNode.cpp
 	AutoQuitNode.cpp)
 SET(SUPRA_Lib_HEADERS
 	vec.h
@@ -147,6 +148,7 @@ SET(SUPRA_Lib_HEADERS
 	utilities/FirFilterFactory.h
 	utilities/tinyxml2/tinyxml2.h
 	FrequencyLimiterNode.h
+	StreamSyncNode.h
 	AutoQuitNode.h)
 	
 SET(SUPRA_Lib_INCLUDEDIRS

--- a/src/SupraLib/Container.h
+++ b/src/SupraLib/Container.h
@@ -88,6 +88,7 @@ namespace supra
 			if(location == LocationGpu)
 			{
 				cudaSafeCall(cudaMemcpyAsync(this->get(), data.data(), this->size() * sizeof(T), cudaMemcpyHostToDevice, associatedStream));
+				cudaSafeCall(cudaStreamSynchronize(associatedStream));
 			}
 			else if(location == LocationBoth)
 			{
@@ -120,6 +121,7 @@ namespace supra
 			else if (source.m_location == LocationHost && location == LocationGpu)
 			{
 				cudaSafeCall(cudaMemcpyAsync(this->get(), source.get(), source.size() * sizeof(T), cudaMemcpyHostToDevice, source.getStream()));
+				cudaSafeCall(cudaStreamSynchronize(source.getStream()));
 			}
 			else if (source.m_location == LocationGpu && location == LocationHost)
 			{

--- a/src/SupraLib/Container.h
+++ b/src/SupraLib/Container.h
@@ -120,11 +120,13 @@ namespace supra
 		~Container()
 		{
 			auto ret = cudaStreamQuery(m_associatedStream);
-			if (ret != cudaSuccess && ret != cudaErrorNotReady)
+			if (ret != cudaSuccess && ret != cudaErrorNotReady && ret != cudaErrorCudartUnloading)
 			{
 				cudaSafeCall(ret);
 			}
-			else {
+			// If the driver is currently unloading, we cannot free the memory in any way. Exit will clean up.
+			else if(ret != cudaErrorCudartUnloading)
+			{
 				if (ret == cudaSuccess)
 				{
 					ContainerFactoryContainerInterface::returnMemory(reinterpret_cast<uint8_t*>(m_buffer), m_numel * sizeof(T), m_location);

--- a/src/SupraLib/ContainerFactory.cpp
+++ b/src/SupraLib/ContainerFactory.cpp
@@ -63,7 +63,7 @@ namespace supra
 			if (location == LocationGpu || location == LocationBoth)
 			{
 				cudaSafeCall(cudaMemGetInfo(&memoryFree, &memoryTotal));
-				memoryFree = static_cast<size_t>(std::max(static_cast<double>(memoryTotal) *0.01, 0.0));
+				memoryFree = static_cast<size_t>(std::max(static_cast<double>(memoryFree) - (static_cast<double>(memoryTotal) *0.02), 0.0));
 			}
 			else
 			{

--- a/src/SupraLib/ContainerFactory.cpp
+++ b/src/SupraLib/ContainerFactory.cpp
@@ -1,0 +1,50 @@
+// ================================================================================================
+// 
+// If not explicitly stated: Copyright (C) 2017, all rights reserved,
+//      Rüdiger Göbl 
+//		Email r.goebl@tum.de
+//      Chair for Computer Aided Medical Procedures
+//      Technische Universität München
+//      Boltzmannstr. 3, 85748 Garching b. München, Germany
+// 
+// ================================================================================================
+
+#include "ContainerFactory.h"
+
+#include <utilities/Logging.h>
+using namespace std;
+
+namespace supra
+{
+	ContainerFactory::ContainerStreamType ContainerFactory::getNextStream()
+	{
+		std::lock_guard<std::mutex> streamLock(sm_streamMutex);
+
+		if (sm_streams.size() == 0)
+		{
+			initStreams();
+		}
+
+		size_t streamIndex = sm_streamIndex;
+		sm_streamIndex = (sm_streamIndex + 1) % sm_numberStreams;
+		return sm_streams[streamIndex];
+	}
+	void ContainerFactory::initStreams()
+	{
+		logging::log_log("ContainerFactory: Initializing ", sm_numberStreams, " streams.");
+		sm_streamIndex = 0;
+#ifdef HAVE_CUDA
+		sm_streams.resize(sm_numberStreams);
+		for (size_t k = 0; k < sm_numberStreams; k++)
+		{
+			cudaSafeCall(cudaStreamCreateWithFlags(&(sm_streams[k]), cudaStreamNonBlocking));
+		}
+#else
+		sm_streams.resize(sm_numberStreams, 0);
+#endif
+	}
+
+	std::vector<ContainerFactory::ContainerStreamType> ContainerFactory::sm_streams = {};
+	size_t ContainerFactory::sm_streamIndex = 0;
+	std::mutex ContainerFactory::sm_streamMutex;
+}

--- a/src/SupraLib/ContainerFactory.cpp
+++ b/src/SupraLib/ContainerFactory.cpp
@@ -12,6 +12,10 @@
 #include "ContainerFactory.h"
 
 #include <utilities/Logging.h>
+#include <utilities/utility.h>
+
+#include <sstream>
+#include <cassert>
 using namespace std;
 
 namespace supra
@@ -29,6 +33,75 @@ namespace supra
 		sm_streamIndex = (sm_streamIndex + 1) % sm_numberStreams;
 		return sm_streams[streamIndex];
 	}
+	uint8_t* ContainerFactory::acquireMemory(size_t numBytes, ContainerLocation location)
+	{
+		assert(location < LocationINVALID);
+		
+		// Check whether the queue for this location and size has a buffer left
+		uint8_t* buffer = nullptr;
+		{
+			// by directly accessing the desired length in the map sm_bufferMaps[location],
+			// the map entry is created if it does not already exist. That means the map is
+			// modified here
+			tbb::concurrent_queue<std::pair<uint8_t*, double> >* queuePointer =
+				&(sm_bufferMaps[location][numBytes]);
+
+			std::pair<uint8_t*, double> queueEntry;
+			if (queuePointer->try_pop(queueEntry))
+			{
+				// If yes, just return this already allocated buffer
+				buffer = queueEntry.first;
+			}
+		}
+
+		// If the queue did not contain a buffer, allocate a new one
+		if (!buffer)
+		{
+			// Check whether there is enough free space for the requested buffer. 
+			size_t memoryFree;
+			size_t memoryTotal;
+			if (location == LocationGpu || location == LocationBoth)
+			{
+				cudaSafeCall(cudaMemGetInfo(&memoryFree, &memoryTotal));
+				memoryFree = static_cast<size_t>(std::max(static_cast<double>(memoryTotal) *0.01, 0.0));
+			}
+			else
+			{
+				// For the host memory we just rely on the 
+				memoryFree = numBytes;
+			}
+
+			// If not, relase enough unused buffers, starting with the ones that have been returned the longest time ago.
+			if (memoryFree < numBytes)
+			{
+				freeBuffers(numBytes, location);
+			}
+
+			// additionaly, release memory that has been returned over XX (e.g. 30) seconds ago
+			freeOldBuffers();
+
+			// Now that we have made the required memory available, we can allocate the buffer
+			buffer = allocateMemory(numBytes, location);
+		}
+
+		return buffer;
+	}
+
+	void ContainerFactory::returnMemory(uint8_t* pointer, size_t numBytes, ContainerLocation location)
+	{
+		assert(location < LocationINVALID);
+
+		// do not free here, just put it back to the queues with the time it was returned at
+		double returnTime = getCurrentTime();
+
+		// Put buffer back to queue
+		{
+			tbb::concurrent_queue<std::pair<uint8_t*, double> >* queuePointer =
+				&(sm_bufferMaps[location][numBytes]);
+
+			queuePointer->push(std::make_pair(pointer, returnTime));
+		}
+	}
 	void ContainerFactory::initStreams()
 	{
 		logging::log_log("ContainerFactory: Initializing ", sm_numberStreams, " streams.");
@@ -44,7 +117,128 @@ namespace supra
 #endif
 	}
 
+	uint8_t * ContainerFactory::allocateMemory(size_t numBytes, ContainerLocation location)
+	{
+		uint8_t* buffer = nullptr;
+		switch (location)
+		{
+		case LocationGpu:
+#ifdef HAVE_CUDA
+			cudaSafeCall(cudaMalloc((void**)&buffer, numBytes));
+#endif
+			break;
+		case LocationBoth:
+#ifdef HAVE_CUDA
+			cudaSafeCall(cudaMallocManaged((void**)&buffer, numBytes));
+#endif
+			break;
+		case LocationHost:
+#ifdef HAVE_CUDA
+			cudaSafeCall(cudaMallocHost((void**)&buffer, numBytes));
+#else
+			buffer = new uint8_t[numBytes];
+#endif
+			break;
+		default:
+			throw std::runtime_error("invalid argument: Container: Unknown location given");
+		}
+		if (!buffer)
+		{
+			std::stringstream s;
+			s << "bad alloc: Container: Error allocating buffer of size " << numBytes << " in "
+				<< (location == LocationHost ? "LocationHost" : (location == LocationGpu ? "LocationGpu" : "LocationBoth"));
+			throw std::runtime_error(s.str());
+		}
+
+		return buffer;
+	}
+
+	void ContainerFactory::freeBuffers(size_t numBytesMin, ContainerLocation location)
+	{
+		size_t numBytesFreed = 0;
+		size_t numBuffersFreed;
+		do 
+		{
+			numBuffersFreed = 0;
+			// by traversing the map sm_bufferMaps[location] we never create new entries, but only modifiy those already present.
+			for (auto mapIterator = sm_bufferMaps[location].begin(); mapIterator != sm_bufferMaps[location].end(); mapIterator++)
+			{
+				size_t numBytesBuffer = mapIterator->first;
+				std::pair<uint8_t*, double> queueEntry;
+				if(mapIterator->second.try_pop(queueEntry))
+				{
+					// If there is an element in this queue, remove it and free the memory
+					freeMemory(queueEntry.first, numBytesBuffer, location);
+					numBytesFreed += numBytesBuffer;
+					numBuffersFreed++;
+				}
+			}
+		} while (numBytesFreed < numBytesMin && numBuffersFreed > 0);
+	}
+
+	void ContainerFactory::freeOldBuffers()
+	{
+		double currentTime = getCurrentTime();
+		double deleteTime = currentTime - sm_deallocationTimeout;
+		for (ContainerLocation location = LocationHost; location < LocationINVALID; location = static_cast<ContainerLocation>(location + 1))
+		{
+			for (auto mapIterator = sm_bufferMaps[location].begin(); mapIterator != sm_bufferMaps[location].end(); mapIterator++)
+			{
+				size_t numBytesBuffer = mapIterator->first;
+
+				double lastTime = 0.0;
+				while(!mapIterator->second.empty() && lastTime < deleteTime)
+				{
+					// If there is an element in this queue, remove it and free the memory
+					std::pair<uint8_t*, double> bufferPair;
+					if (mapIterator->second.try_pop(bufferPair))
+					{
+						lastTime = bufferPair.second;
+						if (lastTime < deleteTime)
+						{
+							freeMemory(bufferPair.first, numBytesBuffer, location);
+						}
+						else
+						{
+							// oops, we should not have taken that element from the queue. Let's just put it back.
+							// Yes, it will be in the wrong temporal order, but that will be solved in a while on its own
+							mapIterator->second.push(bufferPair);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	void ContainerFactory::freeMemory(uint8_t * pointer, size_t numBytes, ContainerLocation location)
+	{
+		switch (location)
+		{
+		case LocationGpu:
+#ifdef HAVE_CUDA
+			cudaFree(pointer);
+#endif
+			break;
+		case LocationBoth:
+#ifdef HAVE_CUDA
+			cudaFree(pointer);
+#endif
+			break;
+		case LocationHost:
+#ifdef HAVE_CUDA
+			cudaFreeHost(pointer);
+#else
+			delete[] pointer;
+#endif
+			break;
+		default:
+			break;
+		}
+	}
+
 	std::vector<ContainerFactory::ContainerStreamType> ContainerFactory::sm_streams = {};
 	size_t ContainerFactory::sm_streamIndex = 0;
 	std::mutex ContainerFactory::sm_streamMutex;
+
+	std::array<tbb::concurrent_unordered_map<size_t, tbb::concurrent_queue<std::pair<uint8_t*, double> > >, LocationINVALID> ContainerFactory::sm_bufferMaps;
 }

--- a/src/SupraLib/ContainerFactory.h
+++ b/src/SupraLib/ContainerFactory.h
@@ -15,28 +15,60 @@
 #ifdef HAVE_CUDA
 #include "utilities/cudaUtility.h"
 #endif
-#include "Container.h"
 
 #include <vector>
 #include <mutex>
+#include <tbb/concurrent_unordered_map.h>
+#include <tbb/concurrent_queue.h>
 
 namespace supra
 {
+	enum ContainerLocation
+	{
+		LocationHost,
+		LocationGpu,
+		LocationBoth,
+		LocationINVALID
+	};
+
 	class ContainerFactory
 	{
 	public:
-		typedef Container<int>::ContainerStreamType ContainerStreamType;
-
+#ifdef HAVE_CUDA
+		typedef cudaStream_t ContainerStreamType;
+#else
+		typedef int ContainerStreamType;
+#endif
+		
 		static ContainerStreamType getNextStream();
+
+	protected:
+		static uint8_t* acquireMemory(size_t numBytes, ContainerLocation location);
+		static void returnMemory(uint8_t* pointer, size_t numBytes, ContainerLocation location);
 
 	private:
 		static void initStreams();
-
+	
 		static constexpr size_t sm_numberStreams = 16;
 
 		static std::vector<ContainerStreamType> sm_streams;
 		static size_t sm_streamIndex;
 		static std::mutex sm_streamMutex;
+
+		static constexpr double sm_deallocationTimeout = 60; // [seconds]
+
+		static uint8_t* allocateMemory(size_t numBytes, ContainerLocation location);
+		static void freeBuffers(size_t numBytesMin, ContainerLocation location);
+		static void freeOldBuffers();
+		static void freeMemory(uint8_t* pointer, size_t numBytes, ContainerLocation location);
+
+		static std::array<tbb::concurrent_unordered_map<size_t, tbb::concurrent_queue<std::pair<uint8_t*, double> > >, LocationINVALID> sm_bufferMaps;
+		//static std::array<std::mutex, LocationINVALID> sm_bufferMutexes;
+	};
+
+	class ContainerFactoryContainerInterface : public ContainerFactory
+	{
+		template <typename T> friend class Container;
 	};
 }
 

--- a/src/SupraLib/ContainerFactory.h
+++ b/src/SupraLib/ContainerFactory.h
@@ -1,0 +1,43 @@
+// ================================================================================================
+// 
+// If not explicitly stated: Copyright (C) 2017, all rights reserved,
+//      Rüdiger Göbl 
+//		Email r.goebl@tum.de
+//      Chair for Computer Aided Medical Procedures
+//      Technische Universität München
+//      Boltzmannstr. 3, 85748 Garching b. München, Germany
+// 
+// ================================================================================================
+
+#ifndef __CONTAINERFACTORY_H__
+#define __CONTAINERFACTORY_H__
+
+#ifdef HAVE_CUDA
+#include "utilities/cudaUtility.h"
+#endif
+#include "Container.h"
+
+#include <vector>
+#include <mutex>
+
+namespace supra
+{
+	class ContainerFactory
+	{
+	public:
+		typedef Container<int>::ContainerStreamType ContainerStreamType;
+
+		static ContainerStreamType getNextStream();
+
+	private:
+		static void initStreams();
+
+		static constexpr size_t sm_numberStreams = 16;
+
+		static std::vector<ContainerStreamType> sm_streams;
+		static size_t sm_streamIndex;
+		static std::mutex sm_streamMutex;
+	};
+}
+
+#endif //!__CONTAINERFACTORY_H__

--- a/src/SupraLib/InputOutput/MetaImageOutputDevice.cpp
+++ b/src/SupraLib/InputOutput/MetaImageOutputDevice.cpp
@@ -365,7 +365,7 @@ namespace supra
 					pData = imageData->getData();
 				}
 				else {
-					pDataCopy = imageData->getData()->getCopy(ContainerLocation::LocationHost);
+					pDataCopy = make_shared<Container<ElementType> >(LocationHost, *(imageData->getData()));
 					pData = pDataCopy;
 				}
 
@@ -385,14 +385,14 @@ namespace supra
 			size_t numSamples = rawData->getNumSamples();
 			size_t numScanlines = rawData->getNumScanlines();
 
-			shared_ptr<Container<int16_t> > pDataCopy;
-			shared_ptr<const Container<int16_t> > pData;
+			shared_ptr<Container<ElementType> > pDataCopy;
+			shared_ptr<const Container<ElementType> > pData;
 			if (rawData->getData()->isHost())
 			{
 				pData = rawData->getData();
 			}
 			else {
-				pDataCopy = rawData->getData()->getCopy(ContainerLocation::LocationHost);
+				pDataCopy = make_shared<Container<int16_t> >(LocationHost, *(rawData->getData()));
 				pData = pDataCopy;
 			}
 			double resolution = rawData->getImageProperties()->getSampleDistance();

--- a/src/SupraLib/InputOutput/OpenIGTLinkOutputDevice.cpp
+++ b/src/SupraLib/InputOutput/OpenIGTLinkOutputDevice.cpp
@@ -165,7 +165,7 @@ namespace supra
 			auto imageContainer = imageData->getData();
 			if (!imageContainer->isHost())
 			{
-				imageContainer = imageContainer->getCopy(LocationHost);
+				imageContainer = make_shared<Container<T> >(LocationHost, *imageContainer);
 			}
 
 			size_t numElements = imageSize.x * imageSize.y * imageSize.z;

--- a/src/SupraLib/InputOutput/UltrasoundInterfaceRawDataMock.cpp
+++ b/src/SupraLib/InputOutput/UltrasoundInterfaceRawDataMock.cpp
@@ -12,14 +12,15 @@
 //
 // ================================================================================================
 
-#include <memory>
-
 #include "USImage.h"
 #include "Beamformer/USRawData.h"
 #include "UltrasoundInterfaceRawDataMock.h"
 #include "utilities/utility.h"
 
 #include "Beamformer/RxBeamformerCuda.h"
+#include "ContainerFactory.h"
+
+#include <memory>
 
 using namespace std;
 
@@ -162,10 +163,10 @@ namespace supra
 
 	void UltrasoundInterfaceRawDataMock::readNextFrame()
 	{
-		auto mockDataHost = make_shared<Container<int16_t> >(LocationHost, m_numel);
+		auto mockDataHost = make_shared<Container<int16_t> >(LocationHost, ContainerFactory::getNextStream(), m_numel);
 
 		m_mockDataStreams[m_sequenceIndex]->read(reinterpret_cast<char*>(mockDataHost->get()), m_numel * sizeof(int16_t));
-		m_pMockData = mockDataHost->getCopy(LocationGpu);
+		m_pMockData = make_shared<Container<int16_t> >(LocationGpu, *mockDataHost);
 		// advance to the next image and sequence where required
 		m_frameIndex = (m_frameIndex + 1) % m_sequenceLengths[m_sequenceIndex];
 		if (m_frameIndex == 0)

--- a/src/SupraLib/InputOutput/UltrasoundInterfaceSimulated.cpp
+++ b/src/SupraLib/InputOutput/UltrasoundInterfaceSimulated.cpp
@@ -12,11 +12,12 @@
 //
 // ================================================================================================
 
-#include <memory>
-
 #include "USImage.h"
 #include "UltrasoundInterfaceSimulated.h"
 #include "utilities/utility.h"
+#include "ContainerFactory.h"
+
+#include <memory>
 
 using namespace std;
 
@@ -79,7 +80,7 @@ namespace supra
 
 				int modValue = rand() % std::min((int)(255 * m_gain), 255);
 
-				auto pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, m_bmodeNumVectors*m_bmodeNumSamples);
+				auto pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, ContainerFactory::getNextStream(), m_bmodeNumVectors*m_bmodeNumSamples);
 				for (size_t k = 0; k < m_bmodeNumSamples; ++k)
 				{
 					uint8_t* dummyData = (pData->get()) + (k*m_bmodeNumVectors);

--- a/src/SupraLib/InputOutput/UltrasoundInterfaceUltrasonix.cpp
+++ b/src/SupraLib/InputOutput/UltrasoundInterfaceUltrasonix.cpp
@@ -15,12 +15,14 @@
 
 #include "UltrasoundInterfaceUltrasonix.h"
 
-#include <string>
-#include <iostream>
-#include <vector>
 #include <Utilities/utility.h>
 #include <utilities/Logging.h>
 #include <utilities/CallFrequency.h>
+#include <ContainerFactory.h>
+
+#include <string>
+#include <iostream>
+#include <vector>
 
 using namespace std;
 using namespace supra::logging;
@@ -29,8 +31,6 @@ using namespace supra::logging;
 
 namespace supra
 {
-
-
 	UltrasoundInterfaceUltrasonix* g_pUSLib = 0;
 
 	UltrasoundInterfaceUltrasonix::UltrasoundInterfaceUltrasonix(tbb::flow::graph& graph, const std::string& nodeID)
@@ -259,7 +259,7 @@ namespace supra
 
 				// copy the data into a buffer managed by us (i.e. a shared pointer)
 				// and create the image
-				auto spData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, m_bmodeNumSamples*m_bmodeNumVectors);
+				auto spData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, ContainerFactory::getNextStream(), m_bmodeNumSamples*m_bmodeNumVectors);
 				memcpyTransposed(spData->get(), (uint8_t*)(packet->pData), m_bmodeNumVectors, m_bmodeNumSamples);
 				shared_ptr<USImage<uint8_t> > pImage = make_shared < USImage<uint8_t> >(
 					vec2s{ m_bmodeNumVectors, m_bmodeNumSamples }, spData, m_pImageProperties, packet->dTimestamp, packet->dTimestamp + m_hostToUSOffsetInSec);
@@ -279,7 +279,7 @@ namespace supra
 
 				// copy the data into a buffer managed by us (i.e. a shared pointer)
 				// and create the image
-				auto spData = make_shared<Container<int16_t> >(ContainerLocation::LocationHost, m_rfNumSamples*m_rfNumVectors);
+				auto spData = make_shared<Container<int16_t> >(ContainerLocation::LocationHost, ContainerFactory::getNextStream(), m_rfNumSamples*m_rfNumVectors);
 				memcpyTransposed(spData->get(), (int16_t*)(packet->pData), m_rfNumVectors, m_rfNumSamples);
 				shared_ptr<USImage<int16_t> > pImage = make_shared < USImage<int16_t> >(
 					vec2s{ m_rfNumVectors, m_rfNumSamples }, spData, m_pImageProperties, packet->dTimestamp, packet->dTimestamp + m_hostToUSOffsetInSec);

--- a/src/SupraLib/InputOutput/UsIntCephasonicsBmode.cpp
+++ b/src/SupraLib/InputOutput/UsIntCephasonicsBmode.cpp
@@ -31,6 +31,7 @@
 #include "utilities/utility.h"
 #include "utilities/CallFrequency.h"
 #include "utilities/Logging.h"
+#include "ContainerFactory.h"
 
 using namespace std;
 using namespace cs;
@@ -191,7 +192,7 @@ namespace supra
 			size_t numVectors = frameBuffer->getNx();
 			size_t numSamples = frameBuffer->getNy();
 
-			shared_ptr<Container<uint8_t> > pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, numVectors*numSamples);
+			shared_ptr<Container<uint8_t> > pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, ContainerFactory::getNextStream(), numVectors*numSamples);
 			std::memcpy(pData->get(), frameBuffer->getBuf(), numVectors*numSamples);
 
 			pImage = make_shared<USImage<uint8_t> >(

--- a/src/SupraLib/InputOutput/UsIntCephasonicsBtcc.cpp
+++ b/src/SupraLib/InputOutput/UsIntCephasonicsBtcc.cpp
@@ -55,6 +55,7 @@
 #include "utilities/utility.h"
 #include "utilities/CallFrequency.h"
 #include "utilities/Logging.h"
+#include "ContainerFactory.h"
 
 namespace supra
 {
@@ -832,7 +833,7 @@ namespace supra
 
 			if (m_layout == "linear")
 			{
-				shared_ptr<Container<uint8_t> > pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, numSamples * numVectors);
+				shared_ptr<Container<uint8_t> > pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, ContainerFactory::getNextStream(), numSamples * numVectors);
 				std::memset(pData->get(), 0, sizeof(uint8_t)*numSamples*numVectors);
 				for (size_t vect = 0; vect < numVectors; vect++)
 				{
@@ -863,7 +864,7 @@ namespace supra
 					numChans = 32;
 				}
 				size_t numRows = numVectors / numChans;
-				shared_ptr<Container<uint8_t> > pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, numChans * numRows);
+				shared_ptr<Container<uint8_t> > pData = make_shared<Container<uint8_t> >(ContainerLocation::LocationHost, ContainerFactory::getNextStream(), numChans * numRows);
 				std::memset(pData->get(), 0, sizeof(uint8_t)*numChans*numRows);
 				for (size_t row = 0; row < numRows; row++)
 				{

--- a/src/SupraLib/InputOutput/UsIntCephasonicsCc.cu
+++ b/src/SupraLib/InputOutput/UsIntCephasonicsCc.cu
@@ -61,6 +61,7 @@
 #include "utilities/utility.h"
 #include "utilities/CallFrequency.h"
 #include "utilities/Logging.h"
+#include "ContainerFactory.h"
 
 namespace supra
 {
@@ -1526,7 +1527,7 @@ namespace supra
 			sNumBeams = numBeams;
 			sNumChannels = numChannels;
 			sArraySize = m_rxNumPlatformsToCopy*m_numChannelsPerPlatform * numSamples * sNumBeams;
-			pData = make_shared<Container<int16_t> >(ContainerLocation::LocationGpu, sArraySize);
+			pData = make_shared<Container<int16_t> >(ContainerLocation::LocationGpu, ContainerFactory::getNextStream(), sArraySize);
 
 			platformsReceived.assign(m_numPlatforms, false);
 		}
@@ -1537,15 +1538,15 @@ namespace supra
 		if(m_rxPlatformsToCopy[platformIndex])
 		{
 			{
-				auto deviceScrambled = unique_ptr<Container<uint8_t> >(new Container<uint8_t>(LocationGpu, numBytesChannels*numSamples*numBeams));
-				cudaSafeCall(cudaMemcpyAsync(deviceScrambled->get(), dataScrambled, numBytesChannels*numSamples*numBeams*sizeof(uint8_t), cudaMemcpyHostToDevice, cudaStreamPerThread));
+				auto deviceScrambled = unique_ptr<Container<uint8_t> >(new Container<uint8_t>(LocationGpu, pData->getStream(), numBytesChannels*numSamples*numBeams));
+				cudaSafeCall(cudaMemcpyAsync(deviceScrambled->get(), dataScrambled, numBytesChannels*numSamples*numBeams*sizeof(uint8_t), cudaMemcpyHostToDevice, pData->getStream()));
 
 				size_t platformOffset = m_rxPlatformCopyOffset[platformIndex];
 				dim3 blockSize(16, 8);
 				dim3 gridSize(
 						static_cast<unsigned int>((numSamples + blockSize.x - 1) / blockSize.x),
 						static_cast<unsigned int>((numBeams + blockSize.y - 1) / blockSize.y));
-				copyUnscramble<<<gridSize, blockSize, 0, cudaStreamPerThread>>>(
+				copyUnscramble<<<gridSize, blockSize, 0, pData->getStream()>>>(
 						numBeams,
 						numSamples,
 						numChannels,
@@ -1555,7 +1556,6 @@ namespace supra
 						deviceScrambled->get(),
 						pData->get());
 				cudaSafeCall(cudaPeekAtLastError());
-				cudaSafeCall(cudaStreamSynchronize(cudaStreamPerThread));
 			}
 			//copy all raw data
 			/*for(size_t beam = 0; beam < numBeams; beam++)
@@ -1644,7 +1644,7 @@ namespace supra
 					m_mockDataWritten = true;
 				}
 
-				pData = make_shared<Container<int16_t> >(ContainerLocation::LocationGpu, sArraySize);
+				pData = make_shared<Container<int16_t> >(ContainerLocation::LocationGpu, ContainerFactory::getNextStream(), sArraySize);
 				platformsReceived.assign(m_numPlatforms, false);
 
 				addData<0>(rawData);

--- a/src/SupraLib/InterfaceFactory.cpp
+++ b/src/SupraLib/InterfaceFactory.cpp
@@ -29,6 +29,7 @@
 #include "Beamformer/LogCompressorNode.h"
 #include "Beamformer/ScanConverterNode.h"
 #include "Beamformer/TemporalFilterNode.h"
+#include "StreamSyncNode.h"
 #include "StreamSynchronizer.h"
 #include "FrequencyLimiterNode.h"
 #include "AutoQuitNode.h"
@@ -147,6 +148,10 @@ namespace supra
 		if (nodeType == "AutoQuitNode")
 		{
 			retVal = make_shared<AutoQuitNode>(*pG, nodeID);
+		}
+		if (nodeType == "StreamSyncNode")
+		{
+			retVal = make_shared<StreamSyncNode>(*pG, nodeID);
 		}
 #ifdef HAVE_BEAMFORMER
 		if (nodeType == "BeamformingNode")

--- a/src/SupraLib/StreamSyncNode.cpp
+++ b/src/SupraLib/StreamSyncNode.cpp
@@ -1,0 +1,61 @@
+// ================================================================================================
+// 
+// If not explicitly stated: Copyright (C) 2017, all rights reserved,
+//      Rüdiger Göbl 
+//		Email r.goebl@tum.de
+//      Chair for Computer Aided Medical Procedures
+//      Technische Universität München
+//      Boltzmannstr. 3, 85748 Garching b. München, Germany
+// 
+// ================================================================================================
+
+#include "StreamSyncNode.h"
+
+#include "USImage.h"
+#include "Beamformer/USRawData.h"
+#include <utilities/Logging.h>
+
+using namespace std;
+
+namespace supra
+{
+	StreamSyncNode::StreamSyncNode(tbb::flow::graph & graph, const std::string & nodeID)
+		: AbstractNode(nodeID)
+		, m_node(graph, 1, [this](shared_ptr<RecordObject> inObj) -> shared_ptr<RecordObject> { return checkTypeAndSynchronize(inObj); })
+	{
+		m_callFrequency.setName(nodeID);
+		configurationChanged();
+	}
+
+	void StreamSyncNode::configurationChanged()
+	{
+	}
+
+	void StreamSyncNode::configurationEntryChanged(const std::string& configKey)
+	{
+	}
+	shared_ptr<RecordObject> StreamSyncNode::checkTypeAndSynchronize(shared_ptr<RecordObject> inObj)
+	{
+		m_callFrequency.measure();
+		if (inObj && (inObj->getType() == TypeUSImage || inObj->getType() == TypeUSRawData))
+		{
+			shared_ptr<USImage<int16_t> >   pInImageInt16 = dynamic_pointer_cast<USImage<int16_t>>(inObj);
+			shared_ptr<USImage<uint8_t> >   pInImageUint8 = dynamic_pointer_cast<USImage<uint8_t>>(inObj);
+			shared_ptr<USRawData<int16_t> > pInImageRaw = dynamic_pointer_cast<USRawData<int16_t>>(inObj);
+			if (pInImageInt16)
+			{
+				cudaSafeCall(cudaStreamSynchronize(pInImageInt16->getData()->getStream()));
+			}
+			else if (pInImageUint8)
+			{
+				cudaSafeCall(cudaStreamSynchronize(pInImageUint8->getData()->getStream()));
+			}
+			else if (pInImageRaw)
+			{
+				cudaSafeCall(cudaStreamSynchronize(pInImageRaw->getData()->getStream()));
+			}
+		}
+		m_callFrequency.measureEnd();
+		return inObj;
+	}
+}

--- a/src/SupraLib/StreamSyncNode.h
+++ b/src/SupraLib/StreamSyncNode.h
@@ -1,0 +1,60 @@
+// ================================================================================================
+// 
+// If not explicitly stated: Copyright (C) 2017, all rights reserved,
+//      Rüdiger Göbl 
+//		Email r.goebl@tum.de
+//      Chair for Computer Aided Medical Procedures
+//      Technische Universität München
+//      Boltzmannstr. 3, 85748 Garching b. München, Germany
+// 
+// ================================================================================================
+
+#ifndef __STREAMSYNCNODE_H__
+#define __STREAMSYNCNODE_H__
+
+#include "AbstractNode.h"
+#include "RecordObject.h"
+
+#include <memory>
+#include <mutex>
+#include <tbb/flow_graph.h>
+
+namespace supra
+{
+	class StreamSyncNode : public AbstractNode {
+	public:
+		typedef tbb::flow::function_node<std::shared_ptr<RecordObject>, std::shared_ptr<RecordObject>, TBB_QUEUE_RESOLVER(false)> nodeType;
+
+	public:
+		StreamSyncNode(tbb::flow::graph& graph, const std::string & nodeID);
+
+		virtual size_t getNumInputs() { return 1; }
+		virtual size_t getNumOutputs() { return 1; }
+
+		virtual tbb::flow::receiver<std::shared_ptr<RecordObject> > * getInput(size_t index) {
+			if (index == 0)
+			{
+				return &m_node;
+			}
+			return nullptr;
+		};
+
+		virtual tbb::flow::sender<std::shared_ptr<RecordObject> > * getOutput(size_t index) {
+			if (index == 0)
+			{
+				return &m_node;
+			}
+			return nullptr;
+		};
+	protected:
+		void configurationEntryChanged(const std::string& configKey);
+		void configurationChanged();
+
+	private:
+		std::shared_ptr<RecordObject> checkTypeAndSynchronize(std::shared_ptr<RecordObject> mainObj);
+
+		nodeType m_node;
+	};
+}
+
+#endif //!__STREAMSYNCNODE_H__

--- a/src/SupraLib/utilities/FirFilterFactory.h
+++ b/src/SupraLib/utilities/FirFilterFactory.h
@@ -60,7 +60,7 @@ namespace supra
 			ElementType omegaBandwidth = static_cast<ElementType>(2 * M_PI* bandwidth / samplingFrequency);
 			int halfWidth = ((int)length - 1) / 2;
 
-			auto filter = std::make_shared<Container<ElementType> >(LocationHost, length);
+			auto filter = std::make_shared<Container<ElementType> >(LocationHost, cudaStreamPerThread, length);
 
 			//determine the filter function
 			std::function<ElementType(int)> filterFunction = [halfWidth](int n) -> ElementType {


### PR DESCRIPTION
This branch contains three major changes:

1. The Container interface is cleaner. Containers are only created through construction instead of the copy-functions that were present before.
2. Containers now carry a CUDA stream on which they have to be used. This allows processing nodes to commit their work to that stream without further synchronization. Only during host <->device copies synchronizations is neccessary.
3. Dynamic memory management: Buffers that are used in the cyclic operation are not allocated and freed cyclically, but are kept by supra (in detail the ContainerFactory.h) instead. This helps to increase performance, as cudaMalloc and cudaFree imply a cudaDeviceSynchronize, thus synchronizeing across all streams.

These changes have been tested on windows (Mock) and Linux with a Cephasonics system.