### PR TITLE
Enable logging by default and 5 second execution for automated testing

### DIFF
--- a/src/CommandlineInterface/main.cpp
+++ b/src/CommandlineInterface/main.cpp
@@ -12,27 +12,51 @@
 #include <utilities/Logging.h>
 
 #include <SupraManager.h>
+#include <chrono>
+#include <thread>
+#include <string>
 #include "CommandlineInterface.h"
 
 using namespace supra;
+using namespace std;
+using namespace std::this_thread;
+using namespace std::chrono;
 
 int main(int argc, char** argv) {
 	logging::Base::setLogLevel(logging::info);
 
 	if (argc == 1)
 	{
-		logging::log_always("Usage: SUPRA_CMD <config.xml>");
+		logging::log_always("Usage: SUPRA_CMD <config.xml> [--test]");
 	}
 	else if (argc >= 2)
 	{
 		SupraManager::Get()->readFromXml(argv[1]);
 
-		SupraManager::Get()->startOutputs();
-		SupraManager::Get()->startInputs();
+		if (argc == 3)
+		{
+			logging::Base::setLogLevel(
+				logging::log |
+				logging::info);
 
-		//Interface
-		CommandlineInterface ui;
-		ui.mainMenu();
+			logging::log_always("Nodes:");
+			for (string nodeID : SupraManager::Get()->getNodeIDs())
+			{
+				logging::log_always(nodeID);
+			}
+			SupraManager::Get()->startOutputs();
+			SupraManager::Get()->startInputs();
+			sleep_until(system_clock::now() + seconds(5));
+		}
+		else
+		{
+			SupraManager::Get()->startOutputs();
+			SupraManager::Get()->startInputs();
+
+			//Interface
+			CommandlineInterface ui;
+			ui.mainMenu();
+		}
 
 		//stop inputs
 		SupraManager::Get()->stopAndWaitInputs();


### PR DESCRIPTION
This doesn't change the original way this application executed but adds the ability to start it with --test and thereby running it for a predefined amount of time to collect the execution output. This allows for automated testing.