### PR TITLE
Updated REST Interface for SUPRA Web Interface

### DIFF
--- a/src/RestInterface/RestInterface.cpp
+++ b/src/RestInterface/RestInterface.cpp
@@ -88,11 +88,11 @@ namespace supra
 				std::string nodeType;
 				// Path example: "GitUrl/parameters/nodeID" nodeID = path[1]
 				if(path.size() > 1)
-                {
-				    nodeType = path[1];
-				    auto response = get_node_parameters(nodeType);
-				    message.reply(status_codes::OK, response);
-                }
+				{
+					nodeType = path[1];
+					auto response = get_node_parameters(nodeType);
+					message.reply(status_codes::OK, response);
+				}
 				else
 				{
 				    message.reply(status_codes::NotFound);

--- a/src/RestInterface/RestInterface.cpp
+++ b/src/RestInterface/RestInterface.cpp
@@ -85,7 +85,7 @@ namespace supra
 			// MARK: Brought the get Parameters under the get requests.
 			else if (path[0] == "parameters")
 			{
-				std::nodeType;
+				std::string nodeType;
 				// Path example: "GitUrl/parameters/nodeID" nodeID = path[1]
 				if(path.size() > 1)
                 {

--- a/src/RestInterface/RestInterface.cpp
+++ b/src/RestInterface/RestInterface.cpp
@@ -85,21 +85,17 @@ namespace supra
 			// MARK: Brought the get Parameters under the get requests.
 			else if (path[0] == "parameters")
 			{
-				auto reqJsonTask = message.extract_json();
-				reqJsonTask.wait();
-				auto reqJson = reqJsonTask.get();
-				if (reqJson.is_object())
+				std::nodeType;
+				// Path example: "GitUrl/parameters/nodeID" nodeID = path[1]
+				if(path.size() > 1)
+                {
+				    nodeType = path[1];
+				    auto response = get_node_parameters(nodeType);
+				    message.reply(status_codes::OK, response);
+                }
+				else
 				{
-					auto reqObj = reqJson.as_object();
-					if (reqObj.find("nodeID") != reqObj.end())
-					{
-						std::string nodeID = reqObj["nodeID"].as_string();
-						auto response = get_node_parameters(nodeID);
-						message.reply(status_codes::OK, response);
-					}
-				}
-				else {
-					message.reply(status_codes::NotFound);
+				    message.reply(status_codes::NotFound);
 				}
 			}
 		}


### PR DESCRIPTION
Changed the way getParameter requests are handled to reflect the http standard.
It now uses the last part of the url sent instead of a json object in the request body, as get request should not have a body.